### PR TITLE
fix bug

### DIFF
--- a/datepicker/src/main/java/com/ycuwq/datepicker/date/DatePicker.java
+++ b/datepicker/src/main/java/com/ycuwq/datepicker/date/DatePicker.java
@@ -170,8 +170,8 @@ public class DatePicker extends LinearLayout implements YearPicker.OnYearSelecte
 
 	@Override
 	public void onYearSelected(int year) {
-		int month = getMonth();
 		mMonthPicker.setYear(year);
+		int month = getMonth();
 		mDayPicker.setMonth(year, month);
 		onDateSelected();
 	}

--- a/datepicker/src/main/java/com/ycuwq/datepicker/date/DayPicker.java
+++ b/datepicker/src/main/java/com/ycuwq/datepicker/date/DayPicker.java
@@ -104,6 +104,7 @@ public class DayPicker extends WheelPicker<Integer>{
 
     public void setSelectedDay(int selectedDay, boolean smoothScroll) {
         setCurrentPosition(selectedDay - mMinDay, smoothScroll);
+        mSelectedDay = selectedDay;
     }
 
     public void setMaxDate(long date) {

--- a/datepicker/src/main/java/com/ycuwq/datepicker/date/MonthPicker.java
+++ b/datepicker/src/main/java/com/ycuwq/datepicker/date/MonthPicker.java
@@ -116,8 +116,8 @@ public class MonthPicker extends WheelPicker<Integer> {
     }
 
     public void setSelectedMonth(int selectedMonth, boolean smoothScroll) {
-
         setCurrentPosition(selectedMonth - mMinMonth, smoothScroll);
+        mSelectedMonth = selectedMonth;
     }
 
 	public void setOnMonthSelectedListener(OnMonthSelectedListener onMonthSelectedListener) {

--- a/sample/src/main/java/com/ycuwq/datepicker/sample/MainActivity.java
+++ b/sample/src/main/java/com/ycuwq/datepicker/sample/MainActivity.java
@@ -9,32 +9,33 @@ import android.widget.Toast;
 import com.ycuwq.datepicker.date.DatePicker;
 import com.ycuwq.datepicker.date.DatePickerDialogFragment;
 
-import java.util.Calendar;
-
 public class MainActivity extends AppCompatActivity {
-	@Override
-	protected void onCreate(Bundle savedInstanceState) {
-		super.onCreate(savedInstanceState);
-		setContentView(R.layout.activity_main);
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main);
 
-		TextView dateTv = findViewById(R.id.tv_date);
-		DatePicker datePicker = findViewById(R.id.datePicker);
-		Button button = findViewById(R.id.button);
-		button.setOnClickListener(v -> {
-			DatePickerDialogFragment datePickerDialogFragment = new DatePickerDialogFragment();
-			datePickerDialogFragment.setOnDateChooseListener(new DatePickerDialogFragment.OnDateChooseListener() {
-				@Override
-				public void onDateChoose(int year, int month, int day) {
-					Toast.makeText(getApplicationContext(), year + "-" + month + "-" + day, Toast.LENGTH_SHORT).show();
-				}
-			});
-			datePickerDialogFragment.show(getFragmentManager(), "DatePickerDialogFragment");
-		});
-		datePicker.setOnDateSelectedListener(new DatePicker.OnDateSelectedListener() {
-			@Override
-			public void onDateSelected(int year, int month, int day) {
-				dateTv.setText(year + "-" + month + "-" + day);
-			}
-		});
-	}
+        TextView dateTv = findViewById(R.id.tv_date);
+        DatePicker datePicker = findViewById(R.id.datePicker);
+        datePicker.setMaxDate(System.currentTimeMillis());
+        datePicker.setMinDate(System.currentTimeMillis() - 100000000000L);
+        Button button = findViewById(R.id.button);
+        button.setOnClickListener(v -> {
+            DatePickerDialogFragment datePickerDialogFragment = new DatePickerDialogFragment();
+            datePickerDialogFragment.setOnDateChooseListener(new DatePickerDialogFragment.OnDateChooseListener() {
+                @Override
+                public void onDateChoose(int year, int month, int day) {
+                    Toast.makeText(getApplicationContext(), year + "-" + month + "-" + day, Toast.LENGTH_SHORT).show();
+                }
+            });
+            datePickerDialogFragment.show(getFragmentManager(), "DatePickerDialogFragment");
+        });
+        datePicker.setOnDateSelectedListener(new DatePicker.OnDateSelectedListener() {
+            @Override
+            public void onDateSelected(int year, int month, int day) {
+                dateTv.setText(year + "-" + month + "-" + day);
+            }
+        });
+    }
+
 }


### PR DESCRIPTION
修复两个 bug.
# bug 1 
代码对应 DatePicker 173 行
bug 复现过程:
1. DatePicker 通过 #setMaxDate 设置为 2019.10.12
2. 用户把年滚轮选择到 2018 年, 月滚轮选择到 11 月或 12 月
3. 当用户再次通过年滚轮选择 2019 年时, 日滚轮没有刷新(换句话说就是可以选择 2019. 10. 30, 可选择的日期超出了设置的最大值). 

问题的原因在于 DatePicker 174 行通过 #setYear 之后会刷新 selectedMonth, 但是在 175 行却将之前的 selectedMonth 设置给了 mDayPicker.

# bug 2
代码对应 MonthPicker 和 DayPicker 中的改动
bug 复现过程:
1. DatePicker 通过 #setMinDate 设置 2016. 8.12
2. 用户把年滚轮滚到 2018 年, 月滚轮调到 1月, 日滚轮调到 1 日
3. 用户再次通过年滚轮把年调到 2016, 月滚轮会刷新到 8 月, 日滚轮刷新到 1 日. 并且 DatePicker#mOnDateSelectedListener 会回调 2016.1.1, 这显然是一个和用户看到不同的结果. 

出现该问题的原因其中一个参见 bug 1. 另外一个原因是调用 MonthPicker#setSelectedMonth 和 DayPicker#setSelectedDay 并不会刷新其内部的 #mSelectedMonth 和 #mSelectedDay 字段. 这两个字段只会在滚轮位置发生变动的时候才会刷新.
直接删掉 WheelPicker 中 776 到 778 这三句代码也可以解决问题. 不过这样会导致每次滚动都会调用 DatePicker#mOnDateSelectedListener 四次, 所以就采取了现在的这种修改方案.
