### PR TITLE
添加时分秒选择器

### DIFF
--- a/datepicker/src/main/java/com/ycuwq/datepicker/time/HourMinuteSecondPicker.java
+++ b/datepicker/src/main/java/com/ycuwq/datepicker/time/HourMinuteSecondPicker.java
@@ -1,0 +1,440 @@
+package com.ycuwq.datepicker.time;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.graphics.Color;
+import android.graphics.drawable.Drawable;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.widget.LinearLayout;
+
+import com.ycuwq.datepicker.R;
+
+
+/**
+ * HourMinuteSecondPicker
+ * 时分秒选择器，秒选择再用一个分选择器实现
+ */
+public class HourMinuteSecondPicker extends LinearLayout implements
+        HourPicker.OnHourSelectedListener,MinutePicker.OnMinuteSelectedListener {
+
+    private HourPicker mHourPicker;
+    private MinutePicker mMinutePicker;
+    private MinutePicker mSecondPicker;
+    private OnTimeSelectedListener mOnTimeSelectedListener;
+
+    public HourMinuteSecondPicker(Context context) {
+        this(context, null);
+    }
+
+    public HourMinuteSecondPicker(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public HourMinuteSecondPicker(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+
+        LayoutInflater.from(context).inflate(R.layout.layout_time_all, this);
+        initChild();
+        initAttrs(context, attrs);
+        mHourPicker.setBackgroundDrawable(getBackground());
+        mMinutePicker.setBackgroundDrawable(getBackground());
+        mSecondPicker.setBackgroundDrawable(getBackground());
+    }
+
+    @Override
+    public void onHourSelected(int hour) {
+        onTimeSelected();
+    }
+
+    @Override
+    public void onMinuteSelected(int minute) {onTimeSelected();}
+
+    private void initAttrs(Context context, AttributeSet attrs) {
+        if (attrs == null) {
+            return;
+        }
+        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.HourMinuteSecondPicker);
+        int textSize = a.getDimensionPixelSize(R.styleable.HourMinuteSecondPicker_itemTextSize,
+                getResources().getDimensionPixelSize(R.dimen.WheelItemTextSize));
+        int textColor = a.getColor(R.styleable.HourMinuteSecondPicker_itemTextColor,
+                Color.BLACK);
+        boolean isTextGradual = a.getBoolean(R.styleable.HourMinuteSecondPicker_textGradual, true);
+        boolean isCyclic = a.getBoolean(R.styleable.HourMinuteSecondPicker_wheelCyclic, true);
+        int halfVisibleItemCount = a.getInteger(R.styleable.HourMinuteSecondPicker_halfVisibleItemCount, 2);
+        int selectedItemTextColor = a.getColor(R.styleable.HourMinuteSecondPicker_selectedTextColor,
+                getResources().getColor(R.color.com_ycuwq_datepicker_selectedTextColor));
+        int selectedItemTextSize = a.getDimensionPixelSize(R.styleable.HourMinuteSecondPicker_selectedTextSize,
+                getResources().getDimensionPixelSize(R.dimen.WheelSelectedItemTextSize));
+        int itemWidthSpace = a.getDimensionPixelSize(R.styleable.HourMinuteSecondPicker_itemWidthSpace,
+                getResources().getDimensionPixelOffset(R.dimen.WheelItemWidthSpace));
+        int itemHeightSpace = a.getDimensionPixelSize(R.styleable.HourMinuteSecondPicker_itemHeightSpace,
+                getResources().getDimensionPixelOffset(R.dimen.WheelItemHeightSpace));
+        boolean isZoomInSelectedItem = a.getBoolean(R.styleable.HourMinuteSecondPicker_zoomInSelectedItem, true);
+        boolean isShowCurtain = a.getBoolean(R.styleable.HourMinuteSecondPicker_wheelCurtain, true);
+        int curtainColor = a.getColor(R.styleable.HourMinuteSecondPicker_wheelCurtainColor, Color.WHITE);
+        boolean isShowCurtainBorder = a.getBoolean(R.styleable.HourMinuteSecondPicker_wheelCurtainBorder, true);
+        int curtainBorderColor = a.getColor(R.styleable.HourMinuteSecondPicker_wheelCurtainBorderColor,
+                getResources().getColor(R.color.com_ycuwq_datepicker_divider));
+        a.recycle();
+
+        setTextSize(textSize);
+        setTextColor(textColor);
+        setTextGradual(isTextGradual);
+        setCyclic(isCyclic);
+        setHalfVisibleItemCount(halfVisibleItemCount);
+        setSelectedItemTextColor(selectedItemTextColor);
+        setSelectedItemTextSize(selectedItemTextSize);
+        setItemWidthSpace(itemWidthSpace);
+        setItemHeightSpace(itemHeightSpace);
+        setZoomInSelectedItem(isZoomInSelectedItem);
+        setShowCurtain(isShowCurtain);
+        setCurtainColor(curtainColor);
+        setShowCurtainBorder(isShowCurtainBorder);
+        setCurtainBorderColor(curtainBorderColor);
+    }
+
+    private void initChild() {
+        mHourPicker = findViewById(R.id.hourPicker_layout_time);
+        mHourPicker.setOnHourSelectedListener(this);
+        mMinutePicker = findViewById(R.id.minutePicker_layout_time);
+        mMinutePicker.setOnMinuteSelectedListener(this);
+        mSecondPicker = findViewById(R.id.secondPicker_layout_time);
+        mSecondPicker.setOnMinuteSelectedListener(this);
+
+    }
+
+    private void onTimeSelected() {
+        if (mOnTimeSelectedListener != null) {
+            mOnTimeSelectedListener.onTimeSelected(getHour(), getMinute(), getSecond());
+        }
+    }
+
+
+    /**
+     * Sets time.
+     *
+     * @param hour   the year
+     * @param minute the month
+     */
+    public void setTime(int hour, int minute, int second) {
+        setTime(hour, minute, second, true);
+    }
+
+    /**
+     * Sets time.
+     *
+     * @param hour         the year
+     * @param minute       the month
+     * @param smoothScroll the smooth scroll
+     */
+    public void setTime(int hour, int minute, int second, boolean smoothScroll) {
+        mHourPicker.setSelectedHour(hour, smoothScroll);
+        mMinutePicker.setSelectedMinute(minute, smoothScroll);
+        mSecondPicker.setSelectedMinute(second, smoothScroll);
+    }
+
+    /**
+     * Gets hour.
+     *
+     * @return the hour
+     */
+    public int getHour() {
+        return mHourPicker.getCurrentPosition();
+    }
+
+
+    /**
+     * Gets minuute.
+     *
+     * @return the minute
+     */
+    public int getMinute() {
+        return mMinutePicker.getCurrentPosition();
+    }
+
+
+    public int getSecond() {
+        return mSecondPicker.getCurrentPosition();
+    }
+
+    @Override
+    public void setBackgroundColor(int color) {
+        super.setBackgroundColor(color);
+        if (mHourPicker != null) {
+            mHourPicker.setBackgroundColor(color);
+        }
+        if (mMinutePicker != null) {
+            mMinutePicker.setBackgroundColor(color);
+        }
+
+        if (mSecondPicker != null) {
+            mSecondPicker.setBackgroundColor(color);
+        }
+    }
+
+    @Override
+    public void setBackgroundResource(int resid) {
+        super.setBackgroundResource(resid);
+        if (mHourPicker != null) {
+            mHourPicker.setBackgroundResource(resid);
+        }
+        if (mMinutePicker != null) {
+            mMinutePicker.setBackgroundResource(resid);
+        }
+        if (mSecondPicker != null) {
+            mSecondPicker.setBackgroundResource(resid);
+        }
+    }
+
+    @Override
+    public void setBackgroundDrawable(Drawable background) {
+        super.setBackgroundDrawable(background);
+        if (mHourPicker != null) {
+            mHourPicker.setBackgroundDrawable(background);
+        }
+        if (mMinutePicker != null) {
+            mMinutePicker.setBackgroundDrawable(background);
+        }
+
+        if (mSecondPicker != null) {
+            mSecondPicker.setBackgroundDrawable(background);
+        }
+    }
+
+    public HourPicker getHourPicker() {
+        return mHourPicker;
+    }
+
+    public MinutePicker getMinutePicker() {
+        return mMinutePicker;
+    }
+
+    public MinutePicker getSecondPicker() {
+        return mSecondPicker;
+    }
+
+    /**
+     * 一般列表的文本颜色
+     *
+     * @param textColor 文本颜色
+     */
+    public void setTextColor(int textColor) {
+        mHourPicker.setTextColor(textColor);
+        mMinutePicker.setTextColor(textColor);
+        mSecondPicker.setTextColor(textColor);
+    }
+
+    /**
+     * 一般列表的文本大小
+     *
+     * @param textSize 文字大小
+     */
+    public void setTextSize(int textSize) {
+        mHourPicker.setTextSize(textSize);
+        mMinutePicker.setTextSize(textSize);
+        mSecondPicker.setTextSize(textSize);
+    }
+
+    /**
+     * 设置被选中时候的文本颜色
+     *
+     * @param selectedItemTextColor 文本颜色
+     */
+    public void setSelectedItemTextColor(int selectedItemTextColor) {
+        mHourPicker.setSelectedItemTextColor(selectedItemTextColor);
+        mMinutePicker.setSelectedItemTextColor(selectedItemTextColor);
+        mSecondPicker.setSelectedItemTextColor(selectedItemTextColor);
+    }
+
+    /**
+     * 设置被选中时候的文本大小
+     *
+     * @param selectedItemTextSize 文字大小
+     */
+    public void setSelectedItemTextSize(int selectedItemTextSize) {
+        mHourPicker.setSelectedItemTextSize(selectedItemTextSize);
+        mMinutePicker.setSelectedItemTextSize(selectedItemTextSize);
+        mSecondPicker.setSelectedItemTextSize(selectedItemTextSize);
+    }
+
+
+    /**
+     * 设置显示数据量的个数的一半。
+     * 为保证总显示个数为奇数,这里将总数拆分，itemCount = mHalfVisibleItemCount * 2 + 1
+     *
+     * @param halfVisibleItemCount 总数量的一半
+     */
+    public void setHalfVisibleItemCount(int halfVisibleItemCount) {
+        mHourPicker.setHalfVisibleItemCount(halfVisibleItemCount);
+        mMinutePicker.setHalfVisibleItemCount(halfVisibleItemCount);
+        mSecondPicker.setHalfVisibleItemCount(halfVisibleItemCount);
+    }
+
+    /**
+     * Sets item width space.
+     *
+     * @param itemWidthSpace the item width space
+     */
+    public void setItemWidthSpace(int itemWidthSpace) {
+        mHourPicker.setItemWidthSpace(itemWidthSpace);
+        mMinutePicker.setItemWidthSpace(itemWidthSpace);
+        mSecondPicker.setItemWidthSpace(itemWidthSpace);
+    }
+
+    /**
+     * 设置两个Item之间的间隔
+     *
+     * @param itemHeightSpace 间隔值
+     */
+    public void setItemHeightSpace(int itemHeightSpace) {
+        mHourPicker.setItemHeightSpace(itemHeightSpace);
+        mMinutePicker.setItemHeightSpace(itemHeightSpace);
+        mSecondPicker.setItemHeightSpace(itemHeightSpace);
+    }
+
+
+    /**
+     * Set zoom in center item.
+     *
+     * @param zoomInSelectedItem the zoom in center item
+     */
+    public void setZoomInSelectedItem(boolean zoomInSelectedItem) {
+        mHourPicker.setZoomInSelectedItem(zoomInSelectedItem);
+        mMinutePicker.setZoomInSelectedItem(zoomInSelectedItem);
+        mSecondPicker.setZoomInSelectedItem(zoomInSelectedItem);
+    }
+
+    /**
+     * 设置是否循环滚动。
+     * set wheel cyclic
+     *
+     * @param cyclic 上下边界是否相邻
+     */
+    public void setCyclic(boolean cyclic) {
+        mHourPicker.setCyclic(cyclic);
+        mMinutePicker.setCyclic(cyclic);
+        mSecondPicker.setCyclic(cyclic);
+    }
+
+    /**
+     * 设置文字渐变，离中心越远越淡。
+     * Set the text color gradient
+     *
+     * @param textGradual 是否渐变
+     */
+    public void setTextGradual(boolean textGradual) {
+        mHourPicker.setTextGradual(textGradual);
+        mMinutePicker.setTextGradual(textGradual);
+        mSecondPicker.setTextGradual(textGradual);
+    }
+
+
+    /**
+     * 设置中心Item是否有幕布遮盖
+     * set the center item curtain cover
+     *
+     * @param showCurtain 是否有幕布
+     */
+    public void setShowCurtain(boolean showCurtain) {
+        mHourPicker.setShowCurtain(showCurtain);
+        mMinutePicker.setShowCurtain(showCurtain);
+        mSecondPicker.setShowCurtain(showCurtain);
+    }
+
+    /**
+     * 设置幕布颜色
+     * set curtain color
+     *
+     * @param curtainColor 幕布颜色
+     */
+    public void setCurtainColor(int curtainColor) {
+        mHourPicker.setCurtainColor(curtainColor);
+        mMinutePicker.setCurtainColor(curtainColor);
+        mSecondPicker.setCurtainColor(curtainColor);
+    }
+
+    /**
+     * 设置幕布是否显示边框
+     * set curtain border
+     *
+     * @param showCurtainBorder 是否有幕布边框
+     */
+    public void setShowCurtainBorder(boolean showCurtainBorder) {
+        mHourPicker.setShowCurtainBorder(showCurtainBorder);
+        mMinutePicker.setShowCurtainBorder(showCurtainBorder);
+        mSecondPicker.setShowCurtainBorder(showCurtainBorder);
+    }
+
+    /**
+     * 幕布边框的颜色
+     * curtain border color
+     *
+     * @param curtainBorderColor 幕布边框颜色
+     */
+    public void setCurtainBorderColor(int curtainBorderColor) {
+        mHourPicker.setCurtainBorderColor(curtainBorderColor);
+        mMinutePicker.setCurtainBorderColor(curtainBorderColor);
+        mSecondPicker.setCurtainBorderColor(curtainBorderColor);
+    }
+
+    /**
+     * 设置选择器的指示器文本
+     * set indicator text
+     *
+     * @param hourText   小时指示器文本
+     * @param minuteText 分钟指示器文本
+     */
+    public void setIndicatorText(String hourText, String minuteText) {
+        mHourPicker.setIndicatorText(hourText);
+        mMinutePicker.setIndicatorText(minuteText);
+        mSecondPicker.setIndicatorText(minuteText);
+    }
+
+    /**
+     * 设置指示器文字的颜色
+     * set indicator text color
+     *
+     * @param textColor 文本颜色
+     */
+    public void setIndicatorTextColor(int textColor) {
+        mHourPicker.setIndicatorTextColor(textColor);
+        mMinutePicker.setIndicatorTextColor(textColor);
+        mSecondPicker.setIndicatorTextColor(textColor);
+    }
+
+    /**
+     * 设置指示器文字的大小
+     * indicator text size
+     *
+     * @param textSize 文本大小
+     */
+    public void setIndicatorTextSize(int textSize) {
+        mHourPicker.setTextSize(textSize);
+        mMinutePicker.setTextSize(textSize);
+        mSecondPicker.setTextSize(textSize);
+    }
+
+    /**
+     * Sets on date selected listener.
+     *
+     * @param onTimeSelectedListener the on time selected listener
+     */
+    public void setOnTimeSelectedListener(OnTimeSelectedListener onTimeSelectedListener) {
+        mOnTimeSelectedListener = onTimeSelectedListener;
+    }
+
+    /**
+     * The interface On date selected listener.
+     */
+    public interface OnTimeSelectedListener {
+        /**
+         * On time selected.
+         *
+         * @param hour   the hour
+         * @param minute the minute
+         * @param second the second
+         */
+        void onTimeSelected(int hour, int minute, int second);
+    }
+}

--- a/datepicker/src/main/java/com/ycuwq/datepicker/time/MinutePicker.java
+++ b/datepicker/src/main/java/com/ycuwq/datepicker/time/MinutePicker.java
@@ -62,6 +62,6 @@ public class MinutePicker extends WheelPicker<Integer> {
     }
 
     public interface OnMinuteSelectedListener {
-        void onMinuteSelected(int hour);
+        void onMinuteSelected(int minute);
     }
 }

--- a/datepicker/src/main/res/layout/layout_time_all.xml
+++ b/datepicker/src/main/res/layout/layout_time_all.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="horizontal"
+    android:background="#f7f7f7"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <com.ycuwq.datepicker.time.HourPicker
+        android:id="@+id/hourPicker_layout_time"
+        app:halfVisibleItemCount="2"
+        app:indicatorText="@string/ycuwq_datepicker_hour"
+        app:wheelCyclic="true"
+        app:indicatorTextSize="12sp"
+        android:layout_weight="1"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content" />
+    <com.ycuwq.datepicker.time.MinutePicker
+        android:id="@+id/minutePicker_layout_time"
+        app:wheelCyclic="true"
+        app:indicatorText="@string/ycuwq_datepicker_minute"
+        app:indicatorTextSize="12sp"
+        app:halfVisibleItemCount="2"
+        android:layout_weight="1"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content" />
+
+    <com.ycuwq.datepicker.time.MinutePicker
+        android:id="@+id/secondPicker_layout_time"
+        app:wheelCyclic="true"
+        app:indicatorText="@string/ycuwq_datepicker_second"
+        app:indicatorTextSize="12sp"
+        app:halfVisibleItemCount="2"
+        android:layout_weight="1"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content" />
+
+</LinearLayout>

--- a/datepicker/src/main/res/values-zh/strings.xml
+++ b/datepicker/src/main/res/values-zh/strings.xml
@@ -4,4 +4,5 @@
     <string name="ycuwq_datepicker_decide">确认</string>
     <string name="ycuwq_datepicker_hour">时</string>
     <string name="ycuwq_datepicker_minute">分</string>
+    <string name="ycuwq_datepicker_second">秒</string>
 </resources>

--- a/datepicker/src/main/res/values/attrs.xml
+++ b/datepicker/src/main/res/values/attrs.xml
@@ -82,4 +82,21 @@
         <attr name="wheelCurtainBorder"/>
         <attr name="wheelCurtainBorderColor"/>
     </declare-styleable>
+
+    <declare-styleable name="HourMinuteSecondPicker">
+        <attr name="halfVisibleItemCount"/>
+        <attr name="itemTextSize"/>
+        <attr name="itemTextColor"/>
+        <attr name="textGradual"/>
+        <attr name="selectedTextColor"/>
+        <attr name="selectedTextSize"/>
+        <attr name="itemWidthSpace"/>
+        <attr name="itemHeightSpace"/>
+        <attr name="zoomInSelectedItem"/>
+        <attr name="wheelCyclic"/>
+        <attr name="wheelCurtain"/>
+        <attr name="wheelCurtainColor"/>
+        <attr name="wheelCurtainBorder"/>
+        <attr name="wheelCurtainBorderColor"/>
+    </declare-styleable>
 </resources>

--- a/datepicker/src/main/res/values/strings.xml
+++ b/datepicker/src/main/res/values/strings.xml
@@ -3,4 +3,5 @@
     <string name="ycuwq_datepicker_decide">Decide</string>
     <string name="ycuwq_datepicker_hour">H</string>
     <string name="ycuwq_datepicker_minute">m</string>
+    <string name="ycuwq_datepicker_second">s</string>
 </resources>


### PR DESCRIPTION
最近公司项目中有时分秒的选择需求，但是原来只支持到时分的选择。
因为秒选择逻辑与分选择逻辑是一样的，在阅读代码之后，得益于作者代码风格简单明了~ 非常棒~发现很容易就能扩展出来。
实现方式为：
在时分选择器中拷贝一份代码，添加时分秒的选择器。
秒选择器使用的是分选择器实现。